### PR TITLE
Update intel-mpi-env.sh

### DIFF
--- a/intel-mpi-env.sh
+++ b/intel-mpi-env.sh
@@ -1,13 +1,13 @@
 #! /bin/bash
 module purge
 
-module load intel/2021.1
-module load intel-mpi/intel/2021.1.1
-module load hdf5/intel-2021.1/intel-mpi/1.10.6
-module load netcdf/intel-2021.1/hdf5-1.10.6/intel-mpi/4.7.4
+module load intel/19.1
+module load intel-mpi/intel/2019.7/64
+module load hdf5/intel-17.0/intel-mpi/1.10.0
+module load netcdf/intel-16.0/hdf5-1.8.16/intel-mpi/4.4.0
 
-export NETCDF=/usr/local/netcdf/intel-2021.1/hdf5-1.10.6/intel-mpi/4.7.4
-export HDF5=/usr/local/hdf5/intel-2021.1/intel-mpi/1.10.6
-
-
-#export NETCDF_classic=1
+export NETCDF=/usr/local/netcdf/intel-16.0/hdf5-1.8.16/intel-mpi/4.4.0
+export HDF5=/usr/local/hdf5/intel-17.0/intel-mpi/1.10.0
+export JASPERLIB=/projects/GEOCLIM/wrf/wrf_libs_intel/lib
+export JASPERINC=/projects/GEOCLIM/wrf/wrf_libs_intel/include
+export NETCDF_classic=1

--- a/intel-mpi-env.sh
+++ b/intel-mpi-env.sh
@@ -1,13 +1,12 @@
-#! /bin/bash
+#!bin/sh
+
 module purge
 
 module load intel/19.1
-module load intel-mpi/intel/2019.7/64
+module load intel-mpi/intel/2019.7
 module load hdf5/intel-17.0/intel-mpi/1.10.0
 module load netcdf/intel-16.0/hdf5-1.8.16/intel-mpi/4.4.0
 
-export NETCDF=/usr/local/netcdf/intel-16.0/hdf5-1.8.16/intel-mpi/4.4.0
-export HDF5=/usr/local/hdf5/intel-17.0/intel-mpi/1.10.0
-export JASPERLIB=/projects/GEOCLIM/wrf/wrf_libs_intel/lib
-export JASPERINC=/projects/GEOCLIM/wrf/wrf_libs_intel/include
+export NETCDF=/usr/local/share/Modules/modulefiles/netcdf/intel-16.0/hdf5-1.8.16/intel-mpi/4.4.0
+export HDF5=/usr/local/share/Modules/modulefiles/hdf5/intel-17.0/intel-mpi/1.10.0
 export NETCDF_classic=1

--- a/intel-mpi-env.sh
+++ b/intel-mpi-env.sh
@@ -1,4 +1,4 @@
-#!bin/sh
+#! bin/bash
 
 module purge
 


### PR DESCRIPTION
Updated the necessary libraries and modules, since 2021 intel modules now don't exist in Tiger/Tigress. Also, uncommented export NETCDF_classic=1 so it runs with the rest of the shell script